### PR TITLE
Fixed build error in MSVC, updated to std library chrono library, etc..

### DIFF
--- a/includes/Allocator.h
+++ b/includes/Allocator.h
@@ -9,9 +9,10 @@ protected:
     std::size_t m_used;   
     std::size_t m_peak;
 public:
-    Allocator(const std::size_t totalSize);
+    
+    Allocator(const std::size_t totalSize) : m_totalSize { totalSize }, m_used { 0 }, m_peak { 0 } { }
 
-    virtual ~Allocator();
+    virtual ~Allocator() { m_totalSize = 0; }
 
     virtual void* Allocate(const std::size_t size, const std::size_t alignment = 0) = 0;
 

--- a/includes/Benchmark.h
+++ b/includes/Benchmark.h
@@ -3,20 +3,33 @@
 
 #include <time.h> // timespec
 #include <cstddef> // std::size_t
+#include <chrono>
+#include <ratio>
 #include <vector>
-#include "Allocator.h" // base class allocator
 
-struct BenchmarkResults {
-	long nOperations;
-	double elapsedTime;
-	float operationsPerSec;
-	float timePerOperation;
-        int memoryPeak;
+#include "Allocator.h" // base class allocator
+#include "IO.h"
+
+#if 0
+#define OPERATIONS (m_nOperations)
+#else
+#define OPERATIONS (10)
+#endif
+
+struct BenchmarkResults
+{
+	std::size_t Operations;
+	std::chrono::milliseconds Milliseconds;
+	double OperationsPerSec;
+	double TimePerOperation;
+    std::size_t MemoryPeak;
 };
 
 class Benchmark {
 public:
-	Benchmark(const unsigned int nOperations);
+    Benchmark() = delete;
+
+    Benchmark(const unsigned int nOperations) : m_nOperations { nOperations } { }
 
 	void SingleAllocation(Allocator* allocator, const std::size_t size, const std::size_t alignment);
 	void SingleFree(Allocator* allocator, const std::size_t size, const std::size_t alignment);
@@ -26,16 +39,35 @@ public:
 
 	void RandomAllocation(Allocator* allocator, const std::vector<std::size_t>& allocationSizes, const std::vector<std::size_t>& alignments);
 	void RandomFree(Allocator* allocator, const std::vector<std::size_t>& allocationSizes, const std::vector<std::size_t>& alignments);
+
 private:
-	void printResults(const BenchmarkResults& results) const;
-	void setTimer(timespec& timer);
+	void PrintResults(const BenchmarkResults& results) const;
+
 	void RandomAllocationAttr(const std::vector<std::size_t>& allocationSizes, const std::vector<std::size_t>& alignments, std::size_t & size, std::size_t & alignment);
 
-	const double calculateElapsedTime() const;
-	const BenchmarkResults buildResults(const unsigned int nOperations, const double elapsedTime, const std::size_t memoryUsed) const;
+	const BenchmarkResults buildResults(std::size_t nOperations, std::chrono::milliseconds&& ellapsedTime, const std::size_t memoryUsed) const;
+    
+    void SetStartTime() noexcept { Start = std::chrono::high_resolution_clock::now(); }
+
+    void SetFinishTime() noexcept { Finish = std::chrono::high_resolution_clock::now(); }
+
+    void SetElapsedTime() noexcept { TimeElapsed = std::chrono::duration_cast<std::chrono::milliseconds>(Finish - Start); }
+
+    void StartRound() noexcept { SetStartTime(); }
+
+    void FinishRound() noexcept
+    {
+        SetFinishTime();
+        SetElapsedTime();
+    }
+
 private:
-	unsigned int m_nOperations;
-	timespec m_start, m_end;
+	std::size_t m_nOperations;
+
+    std::chrono::time_point<std::chrono::high_resolution_clock> Start;
+    std::chrono::time_point<std::chrono::high_resolution_clock> Finish;
+
+    std::chrono::milliseconds TimeElapsed;
 };
 
 #endif /* BENCHMARK_H */

--- a/includes/IO.h
+++ b/includes/IO.h
@@ -1,0 +1,24 @@
+
+#ifndef MEMORY_ALLOCATORS_IO_H_INCLUDED
+#define MEMORY_ALLOCATORS_IO_H_INCLUDED
+
+#include <iostream>
+
+namespace IO
+{
+    // This function replaces the traditional std::endl in order to prevent
+    // the repeated flushing of the output buffer via std::fflush(). Rather,
+    // this function simply outputs a new line, yet it keeps with the
+    // syntax of traditional << std::endl usage.
+    //
+    // Jose Fernando Lopez Fernandez 11/07/2018 @ 2:19am (UTC)
+
+    template <typename T, typename CharT = std::char_traits<T>>
+    std::basic_ostream<T, CharT>&
+        endl(std::basic_ostream<T, CharT>& outputStream)
+    {
+        return outputStream << outputStream.widen('\n');
+    }
+}
+
+#endif // MEMORY_ALLOCATORS_IO_H_INCLUDED

--- a/src/Allocator.cpp
+++ b/src/Allocator.cpp
@@ -1,11 +1,2 @@
 #include "Allocator.h"
 #include <cassert> //assert
-
-Allocator::Allocator(const std::size_t totalSize){
-    m_totalSize = totalSize;
-    m_used = 0;
-}
-
-Allocator::~Allocator(){
-    m_totalSize = 0;
-}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,17 +10,21 @@
 #include "PoolAllocator.h"
 #include "FreeListAllocator.h"
 
-int main() {
+int main()
+{
+    const std::size_t A = static_cast<std::size_t>(1e9);
+    const std::size_t B = static_cast<std::size_t>(1e8);
+
     const std::vector<std::size_t> ALLOCATION_SIZES {32, 64, 256, 512, 1024, 2048, 4096};
     const std::vector<std::size_t> ALIGNMENTS {8, 8, 8, 8, 8, 8, 8};
 
     Allocator * cAllocator = new CAllocator();
-    Allocator * linearAllocator = new LinearAllocator(1e9);
-    Allocator * stackAllocator = new StackAllocator(1e9);
+    Allocator * linearAllocator = new LinearAllocator(A);
+    Allocator * stackAllocator = new StackAllocator(A);
     Allocator * poolAllocator = new PoolAllocator(16777216, 4096);
-    Allocator * freeListAllocator = new FreeListAllocator(1e8, FreeListAllocator::PlacementPolicy::FIND_FIRST);
+    Allocator * freeListAllocator = new FreeListAllocator(B, FreeListAllocator::PlacementPolicy::FIND_FIRST);
 
-    Benchmark benchmark(1e1);
+    Benchmark benchmark(OPERATIONS);
 
     std::cout << "C" << std::endl;
     benchmark.MultipleAllocation(cAllocator, ALLOCATION_SIZES, ALIGNMENTS);


### PR DESCRIPTION
[This error](https://github.com/mtrebi/memory-allocators/issues/6) was due to a combination of things, primarily that the Win32 API does not have a few of the time structs defined in `<sys/types.h>` and `<time.h>`, as well as `<unistd.h>`.

To fix the problem, I changed the time tracking mechanism to the standard library's `chrono::high_resolution_clock`, and updated all the necessary data structures and functions. I also re-added some of the metrics that were commented out. The time elapsed, operations per second, and time per operation metrics are working as expected now.

Excerpt from execution:
```

	BENCHMARK: ALLOCATION
A	@H 00000292BD9D2070	D@ 00000292BD9D2080	S 4112	AP 0	P 16	M 4112	R 99995888
A	@H 00000292BD9D3080	D@ 00000292BD9D3090	S 80	AP 0	P 16	M 4192	R 99995808
A	@H 00000292BD9D30D0	D@ 00000292BD9D30E0	S 4112	AP 0	P 16	M 8304	R 99991696
A	@H 00000292BD9D40E0	D@ 00000292BD9D40F0	S 2064	AP 0	P 16	M 10368	R 99989632
A	@H 00000292BD9D48F0	D@ 00000292BD9D4900	S 528	AP 0	P 16	M 10896	R 99989104
A	@H 00000292BD9D4B00	D@ 00000292BD9D4B10	S 272	AP 0	P 16	M 11168	R 99988832
A	@H 00000292BD9D4C10	D@ 00000292BD9D4C20	S 2064	AP 0	P 16	M 13232	R 99986768
A	@H 00000292BD9D5420	D@ 00000292BD9D5430	S 48	AP 0	P 16	M 13280	R 99986720
A	@H 00000292BD9D5450	D@ 00000292BD9D5460	S 2064	AP 0	P 16	M 15344	R 99984656
A	@H 00000292BD9D5C60	D@ 00000292BD9D5C70	S 4112	AP 0	P 16	M 19456	R 99980544
	RESULTS:
		Operations:    	10
		Time elapsed: 	42 ms
		Op per sec:    	0.238095 ops/ms
		Timer per op:  	4.2 ms/ops
		Memory peak:   	19456 bytes

	BENCHMARK: ALLOCATION/FREE
A	@H 00000292BD9D0070	D@ 00000292BD9D0080	S 4112	AP 0	P 16	M 4112	R 99995888
A	@H 00000292BD9D1080	D@ 00000292BD9D1090	S 80	AP 0	P 16	M 4192	R 99995808
A	@H 00000292BD9D10D0	D@ 00000292BD9D10E0	S 4112	AP 0	P 16	M 8304	R 99991696
A	@H 00000292BD9D20E0	D@ 00000292BD9D20F0	S 2064	AP 0	P 16	M 10368	R 99989632
A	@H 00000292BD9D28F0	D@ 00000292BD9D2900	S 528	AP 0	P 16	M 10896	R 99989104
A	@H 00000292BD9D2B00	D@ 00000292BD9D2B10	S 272	AP 0	P 16	M 11168	R 99988832
A	@H 00000292BD9D2C10	D@ 00000292BD9D2C20	S 2064	AP 0	P 16	M 13232	R 99986768
A	@H 00000292BD9D3420	D@ 00000292BD9D3430	S 48	AP 0	P 16	M 13280	R 99986720
A	@H 00000292BD9D3450	D@ 00000292BD9D3460	S 2064	AP 0	P 16	M 15344	R 99984656
A	@H 00000292BD9D3C60	D@ 00000292BD9D3C70	S 4112	AP 0	P 16	M 19456	R 99980544
	Merging(n) 00000292BD9D3C60 & 0000000000000000	S 99984656
F	@ptr 00000292BD9D3C70	H@ 00000292BD9D3C60	S 99984656	M 15344
	Merging(n) 00000292BD9D3450 & 0000000000000000	S 99986720
F	@ptr 00000292BD9D3460	H@ 00000292BD9D3450	S 99986720	M 13280
	Merging(n) 00000292BD9D3420 & 0000000000000000	S 99986768
F	@ptr 00000292BD9D3430	H@ 00000292BD9D3420	S 99986768	M 13232
	Merging(n) 00000292BD9D2C10 & 0000000000000000	S 99988832
F	@ptr 00000292BD9D2C20	H@ 00000292BD9D2C10	S 99988832	M 11168
	Merging(n) 00000292BD9D2B00 & 0000000000000000	S 99989104
F	@ptr 00000292BD9D2B10	H@ 00000292BD9D2B00	S 99989104	M 10896
	Merging(n) 00000292BD9D28F0 & 0000000000000000	S 99989632
F	@ptr 00000292BD9D2900	H@ 00000292BD9D28F0	S 99989632	M 10368
	Merging(n) 00000292BD9D20E0 & 0000000000000000	S 99991696
F	@ptr 00000292BD9D20F0	H@ 00000292BD9D20E0	S 99991696	M 8304
	Merging(n) 00000292BD9D10D0 & 0000000000000000	S 99995808
F	@ptr 00000292BD9D10E0	H@ 00000292BD9D10D0	S 99995808	M 4192
	Merging(n) 00000292BD9D1080 & 0000000000000000	S 99995888
F	@ptr 00000292BD9D1090	H@ 00000292BD9D1080	S 99995888	M 4112
	Merging(n) 00000292BD9D0070 & 0000000000000000	S 100000000
F	@ptr 00000292BD9D0080	H@ 00000292BD9D0070	S 100000000	M 0
	RESULTS:
		Operations:    	10
		Time elapsed: 	43 ms
		Op per sec:    	0.232558 ops/ms
		Timer per op:  	4.3 ms/ops
		Memory peak:   	19456 bytes
```