### PR TITLE
Fixed StackAllocator having garbage in the header on Free

### DIFF
--- a/includes/StackAllocator.h
+++ b/includes/StackAllocator.h
@@ -10,11 +10,11 @@ protected:
 public:
     StackAllocator(const std::size_t totalSize);
 
-    virtual ~StackAllocator();
+    virtual ~StackAllocator() override;
 
     virtual void* Allocate(const std::size_t size, const std::size_t alignment = 0) override;
 
-    virtual void Free(void* ptr);
+    virtual void Free(void* ptr) override;
 
     virtual void Init() override;
 

--- a/src/StackAllocator.cpp
+++ b/src/StackAllocator.cpp
@@ -27,7 +27,7 @@ StackAllocator::~StackAllocator() {
 void* StackAllocator::Allocate(const std::size_t size, const std::size_t alignment) {
     const std::size_t currentAddress = (std::size_t)m_start_ptr + m_offset;
 
-    std::size_t padding = Utils::CalculatePaddingWithHeader(currentAddress, alignment, sizeof (AllocationHeader));
+    const std::size_t padding = Utils::CalculatePaddingWithHeader(currentAddress, alignment, sizeof (AllocationHeader));
 
     if (m_offset + padding + size > m_totalSize) {
         return nullptr;
@@ -51,7 +51,7 @@ void* StackAllocator::Allocate(const std::size_t size, const std::size_t alignme
     return (void*) nextAddress;
 }
 
-void StackAllocator::Free(void *ptr) {
+void StackAllocator::Free(void* ptr) {
     // Move offset back to clear address
     const std::size_t currentAddress = (std::size_t) ptr;
     const std::size_t headerAddress = currentAddress - sizeof (AllocationHeader);

--- a/src/StackAllocator.cpp
+++ b/src/StackAllocator.cpp
@@ -37,9 +37,9 @@ void* StackAllocator::Allocate(const std::size_t size, const std::size_t alignme
     const std::size_t nextAddress = currentAddress + padding;
     const std::size_t headerAddress = nextAddress - sizeof (AllocationHeader);
     AllocationHeader allocationHeader{padding};
-    AllocationHeader * headerPtr = (AllocationHeader*) headerAddress;
-    headerPtr = &allocationHeader;
-    
+    AllocationHeader* headerPtr = (AllocationHeader*) headerAddress;
+    memcpy(headerPtr,&allocationHeader,sizeof(AllocationHeader));
+
     m_offset += size;
 
 #ifdef _DEBUG


### PR DESCRIPTION
Addressed #8 where calling Free on the StackAllocator would access garbage in the `AllocationHeader`

While I was there I made the points declarations more consistent with the codebase and specified the overriding methods in the definition.

I was going to address #22 in this PR, but after more thought, the highest an alignment should ever be is **64** for 512 SEE intrinsics. So the char shouldn't be an issue and takes up less space than a size_t.
