### PR TITLE
Stack allocator bugfix

### DIFF
--- a/src/StackAllocator.cpp
+++ b/src/StackAllocator.cpp
@@ -38,7 +38,7 @@ void* StackAllocator::Allocate(const std::size_t size, const std::size_t alignme
     const std::size_t headerAddress = nextAddress - sizeof (AllocationHeader);
     AllocationHeader allocationHeader{padding};
     AllocationHeader * headerPtr = (AllocationHeader*) headerAddress;
-    headerPtr = &allocationHeader;
+    *headerPtr = allocationHeader;
     
     m_offset += size;
 


### PR DESCRIPTION
Bugfix of Stack allcoator.
The padding value is not recorded in the header memory when stack allocator allocating memory.