### PR TITLE
Added CMAKE_COMPILE_COMMANDS rule to make the code easier to read after compiling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required (VERSION 3.5)
 project (memory-allocators LANGUAGES CXX)
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 set(SOURCES src/Allocator.cpp
    	src/CAllocator.cpp
    	src/LinearAllocator.cpp


### PR DESCRIPTION
I added set(CMAKE_COMPILE_COMMANDS ON) in the cmake file to prevent linking errors in src files.