### PR TITLE
Refactor stack allocator rollback

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,8 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(SOURCES src/Allocator.cpp
    	src/CAllocator.cpp
    	src/LinearAllocator.cpp
-   	src/StackAllocator
-   	src/PoolAllocator
+    	src/StackAllocator.cpp
+    	src/PoolAllocator.cpp
    	src/FreeListAllocator.cpp
    	src/Benchmark.cpp 
 	src/main.cpp)

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Due to its simplicity, this allocator doesn't allow specific positions of memory
 This is a smart evolution of the Linear Allocator. The idea is to manage the memory as a Stack. So, as before, we keep a pointer to the current memory address and we move it forward for every allocation. However, we also can move it backwards when a free operation is done. As before, we keep the spatial locality principle and the fragmentation is still very low.
 
 ### Data structure
-As I said, we need the pointer (or offset) to keep track of the last allocation. In order to be able to free memory, we also need to store a _header_ for each allocation that tell us the size of the allocated block. Thus, when we free, we know how many positions we have to move back the pointer. 
+The allocator only needs a pointer (or offset) to keep track of the current top of the stack. Rollback points are stored outside the managed block, so allocations do not need a per-allocation header in the returned memory. This avoids wasting padding space and keeps the user-facing memory contiguous.
 
 ![Data structure of a Stack Allocator](https://github.com/mtrebi/memory-allocators/blob/master/docs/images/stack1.png)
 
@@ -80,7 +80,7 @@ Simply move the pointer (or offset) forward and place a header right before the 
 _Complexity: **O(1)**_
 
 ### Free
-Simply read the block size from the header and move the pointer backwards given that size.
+Free is a LIFO rollback. The allocator restores the last saved offset and does not need to inspect any header stored in the allocation itself.
 
 ![Freeing memory in a Stack Allocator](https://github.com/mtrebi/memory-allocators/blob/master/docs/images/stack3.png)
 

--- a/includes/StackAllocator.h
+++ b/includes/StackAllocator.h
@@ -2,11 +2,14 @@
 #define STACKALLOCATOR_H
 
 #include "Allocator.h"
+#include <vector>
 
 class StackAllocator : public Allocator {
 protected:
     void* m_start_ptr = nullptr;
-    std::size_t m_offset;
+    std::size_t m_offset = 0;
+    std::vector<std::size_t> m_markers;
+    std::vector<std::size_t> m_checkpoints;
 public:
     StackAllocator(const std::size_t totalSize);
 
@@ -14,17 +17,15 @@ public:
 
     virtual void* Allocate(const std::size_t size, const std::size_t alignment = 0) override;
 
-    virtual void Free(void* ptr);
+    virtual void Free(void* ptr) override;
 
     virtual void Init() override;
 
     virtual void Reset();
+    std::size_t Push();
+    void Pop(const std::size_t marker);
 private:
     StackAllocator(StackAllocator &stackAllocator);
-
-    struct AllocationHeader {
-        char padding;
-    };
 
 };
 

--- a/src/StackAllocator.cpp
+++ b/src/StackAllocator.cpp
@@ -2,6 +2,7 @@
 #include "Utils.h"  /* CalculatePadding */
 #include <stdlib.h>     /* malloc, free */
 #include <algorithm>    /* max */
+#include <cassert>
 #ifdef _DEBUG
 #include <iostream>
 #endif
@@ -14,9 +15,10 @@ StackAllocator::StackAllocator(const std::size_t totalSize)
 void StackAllocator::Init() {
     if (m_start_ptr != nullptr) {
         free(m_start_ptr);
+        m_start_ptr = nullptr;
     }
     m_start_ptr = malloc(m_totalSize);
-    m_offset = 0;
+    Reset();
 }
 
 StackAllocator::~StackAllocator() {
@@ -27,20 +29,18 @@ StackAllocator::~StackAllocator() {
 void* StackAllocator::Allocate(const std::size_t size, const std::size_t alignment) {
     const std::size_t currentAddress = (std::size_t)m_start_ptr + m_offset;
 
-    std::size_t padding = Utils::CalculatePaddingWithHeader(currentAddress, alignment, sizeof (AllocationHeader));
+    std::size_t padding = 0;
+    if (alignment != 0) {
+        padding = Utils::CalculatePadding(currentAddress, alignment);
+    }
 
     if (m_offset + padding + size > m_totalSize) {
         return nullptr;
     }
-    m_offset += padding;
 
+    m_markers.push_back(m_offset);
     const std::size_t nextAddress = currentAddress + padding;
-    const std::size_t headerAddress = nextAddress - sizeof (AllocationHeader);
-    AllocationHeader allocationHeader{padding};
-    AllocationHeader * headerPtr = (AllocationHeader*) headerAddress;
-    *headerPtr = allocationHeader;
-    
-    m_offset += size;
+    m_offset += padding + size;
 
 #ifdef _DEBUG
     std::cout << "A" << "\t@C " << (void*) currentAddress << "\t@R " << (void*) nextAddress << "\tO " << m_offset << "\tP " << padding << std::endl;
@@ -52,16 +52,15 @@ void* StackAllocator::Allocate(const std::size_t size, const std::size_t alignme
 }
 
 void StackAllocator::Free(void *ptr) {
-    // Move offset back to clear address
-    const std::size_t currentAddress = (std::size_t) ptr;
-    const std::size_t headerAddress = currentAddress - sizeof (AllocationHeader);
-    const AllocationHeader * allocationHeader{ (AllocationHeader *) headerAddress};
+    (void)ptr;
+    assert(!m_markers.empty() && "StackAllocator::Free must follow LIFO order");
 
-    m_offset = currentAddress - allocationHeader->padding - (std::size_t) m_start_ptr;
+    m_offset = m_markers.back();
+    m_markers.pop_back();
     m_used = m_offset;
 
 #ifdef _DEBUG
-    std::cout << "F" << "\t@C " << (void*) currentAddress << "\t@F " << (void*) ((char*) m_start_ptr + m_offset) << "\tO " << m_offset << std::endl;
+    std::cout << "F" << "\t@F " << ptr << "\tO " << m_offset << std::endl;
 #endif
 }
 
@@ -69,4 +68,22 @@ void StackAllocator::Reset() {
     m_offset = 0;
     m_used = 0;
     m_peak = 0;
+    m_markers.clear();
+    m_checkpoints.clear();
+}
+
+std::size_t StackAllocator::Push() {
+    m_checkpoints.push_back(m_offset);
+    return m_offset;
+}
+
+void StackAllocator::Pop(const std::size_t marker) {
+    assert(marker <= m_offset && "StackAllocator::Pop marker must be <= current offset");
+
+    while (!m_checkpoints.empty() && m_checkpoints.back() >= marker) {
+        m_checkpoints.pop_back();
+    }
+
+    m_offset = marker;
+    m_used = m_offset;
 }


### PR DESCRIPTION
Remove the per-allocation header from StackAllocator, store rollback state out of band, and make Free() a strict LIFO rollback. Also fix the CMake source list so StackAllocator.cpp and PoolAllocator.cpp are built.